### PR TITLE
Fix modulo division by zero and correct unit tests

### DIFF
--- a/sources/calc.py
+++ b/sources/calc.py
@@ -33,7 +33,9 @@ def modulo(arg1,arg2):
     try:
         return int(arg1)%int(arg2)
     except ValueError:
-        print("Un des arguments n'est pas un entier")    
+        print("Un des arguments n'est pas un entier")
+    except ZeroDivisionError:
+        print("Modulo par 0 impossible.")
 
 def ope(operateur,arg1,arg2):   
     if operateur=='+':

--- a/sources/test_calc.py
+++ b/sources/test_calc.py
@@ -50,6 +50,12 @@ class Test(unittest.TestCase):
         """
         self.assertIsNone(calc.modulo(8, "da"))
 
+    def test_modulo_zero(self):
+        """
+        Un modulo par 0 ne doit rien retourner.
+        """
+        self.assertIsNone(calc.modulo("8", "0"))
+
     def test_sous_float(self):
         """
         La soustraction entre 2 float ne doit rien retourner.
@@ -72,7 +78,7 @@ class Test(unittest.TestCase):
         """
         La multiplication entre 2 float ne doit rien retourner.
         """
-        self.assertIsNone(calc.sous("0.5", "2.8"))
+        self.assertIsNone(calc.mult("0.5", "2.8"))
 
     def test_div(self):
         """
@@ -102,7 +108,7 @@ class Test(unittest.TestCase):
         """
         La soustraction entre 12 et 2 doit retourner 10.
         """
-        self.assertEqual(calc.sous("12", "2"), 10)
+        self.assertEqual(calc.ope("-", "12", "2"), 10)
 
     def test_ope_erreur(self):
         """


### PR DESCRIPTION
## Summary
- handle ZeroDivisionError in `calc.modulo`
- fix incorrect calls in unit tests
- add a test for modulo by zero

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446e9900888320a1977c9103cec6cb